### PR TITLE
Fix several padding issues

### DIFF
--- a/osc/OSCMessage.js
+++ b/osc/OSCMessage.js
@@ -97,6 +97,8 @@ OSCMessage.prototype.build = function ()
     this.data.push (','.charCodeAt (0));
     for (var i = 0; i < this.types.length; i++)
         this.data.push (this.types[i].charCodeAt (0));
+    if(this.data.length % 4 == 0)
+        this.data.push(0);
     this.alignToFourByteBoundary ();
     
     for (var i = 0; i < this.values.length; i++)
@@ -407,8 +409,14 @@ OSCMessage.prototype.readString = function ()
 
 OSCMessage.prototype.writeString = function (str)
 {
+    if(str.length == 0){
+     this.data.push(0);
+     return;
+    }
     for (var i = 0; i < str.length; i++)
         this.data.push (str.charCodeAt (i));
+    if(str.length % 4 == 0)
+     this.data.push(0);
 };
 
 // A uint32 size count, followed by that many 8-bit bytes of arbitrary binary
@@ -474,6 +482,6 @@ OSCMessage.prototype.skipToFourByteBoundary = function ()
 OSCMessage.prototype.alignToFourByteBoundary = function ()
 {
     var upper = 4 - (this.data.length % 4);
-	for (var i = 0; i < upper; i++)
+	for (var i = 0; upper != 4 && i < upper; i++)
         this.data.push (0);
 };


### PR DESCRIPTION
First Bug:
Even when an OSCMessage datasize was perfectly divisible by 4 it padded
4 bytes to an OSC message, breaking the structure.

Second Bug:
When string with a length of 0 would be sent, padding was not being added in the data buffer. Add a null byte to the data array so when alignToFourByteBoundary was called the OSC message will be the right size.

Third Bug:
When generating the type section of the OSC message (ie ",ffs") if the comma + the number of types was perfectly divisible by four no padding was added and the type section was not being terminated properly.

Fourth Bug:
When sending a string message if the string size was equal to the alignment size correct padding would not be generated.