### PR TITLE
Support sending arrays to OSCWriter/OSCMessage / Better handling of boolean conversion

### DIFF
--- a/osc/OSCMessage.js
+++ b/osc/OSCMessage.js
@@ -14,6 +14,20 @@ OSCMessage.prototype.init = function (address, param, type)
 {
     this.address = address;
     this.types = [];
+    
+    if(param instanceof Array){
+       for(var i=0; i < param.length; i++){
+        this.addArgument(param[i]);
+       }
+    }else{
+       this.addArgument(param,type);
+    }
+    
+
+};
+
+OSCMessage.prototype.addArgument = function (param, type)
+{
     if (param != null)
     {
         switch (typeof (param))

--- a/osc/OSCWriter.js
+++ b/osc/OSCWriter.js
@@ -200,7 +200,9 @@ OSCWriter.prototype.flushFX = function (fxAddress, fxParam, dump)
 
 OSCWriter.prototype.sendOSC = function (address, value, dump)
 {
-    if(!dump && value instanceof Array){
+    if (!dump && this.oldValues[address] === value)
+        return;
+    else if(!dump && value instanceof Array){
         if (address in this.oldValues){
             if(value.length == this.oldValues[address]){
                 var matching = true;
@@ -214,19 +216,19 @@ OSCWriter.prototype.sendOSC = function (address, value, dump)
                     return;
             }
         }
-    }else if (!dump && this.oldValues[address] === value)
-        return;
+    }
     
     this.oldValues[address] = value;
 
     //Convert booleans to int for client compatibility
-    if(value instanceof Array){
+    if(typeof(value) == 'boolean')
+        value = (value) ? 1 : 0;
+    else if(value instanceof Array){
         for(var i=0;i<value.length;i++){
             if(typeof(value[i]) == 'boolean')
                 value[i] = (value[i]) ? 1 : 0;
         }
-    }else if(typeof(value) == 'boolean')
-        value = (value) ? 1 : 0;
+    }
 
     var msg = new OSCMessage ();
     msg.init (address, value);

--- a/osc/OSCWriter.js
+++ b/osc/OSCWriter.js
@@ -200,9 +200,7 @@ OSCWriter.prototype.flushFX = function (fxAddress, fxParam, dump)
 
 OSCWriter.prototype.sendOSC = function (address, value, dump)
 {
-    if (!dump && this.oldValues[address] === value)
-        return;
-    else if(!dump && value instanceof Array){
+    if(!dump && value instanceof Array){
         if (address in this.oldValues){
             if(value.length == this.oldValues[address]){
                 var matching = true;
@@ -216,19 +214,19 @@ OSCWriter.prototype.sendOSC = function (address, value, dump)
                     return;
             }
         }
-    }
+    }else if (!dump && this.oldValues[address] === value)
+        return;
     
     this.oldValues[address] = value;
 
     //Convert booleans to int for client compatibility
-    if(typeof(value) == 'boolean')
-        value = (value) ? 1 : 0;
-    else if(value instanceof Array){
+    if(value instanceof Array){
         for(var i=0;i<value.length;i++){
             if(typeof(value[i]) == 'boolean')
                 value[i] = (value[i]) ? 1 : 0;
         }
-    }
+    }else if(typeof(value) == 'boolean')
+        value = (value) ? 1 : 0;
 
     var msg = new OSCMessage ();
     msg.init (address, value);

--- a/osc/OSCWriter.js
+++ b/osc/OSCWriter.js
@@ -198,9 +198,16 @@ OSCWriter.prototype.flushFX = function (fxAddress, fxParam, dump)
 
 OSCWriter.prototype.sendOSC = function (address, value, dump)
 {
-    if (!dump && this.oldValues[address] === value)
+    if(!dump && value instanceof Array && value.toString() == this.oldValues[address])
         return;
-    this.oldValues[address] = value;
+    else if (!dump && this.oldValues[address] === value)
+        return;
+        
+    if(value instanceof Array)
+        this.oldValues[address] = value.toString();
+    else
+        this.oldValues[address] = value;
+        
     var msg = new OSCMessage ();
     msg.init (address, value);
     this.messages.push (msg.build ());

--- a/osc/OSCWriter.js
+++ b/osc/OSCWriter.js
@@ -206,7 +206,6 @@ OSCWriter.prototype.sendOSC = function (address, value, dump)
                 var matching = true;
                 for(var i=0; i<value.length; i++){
                     if(value[i] != this.oldValues[address][i]){
-                        
                         matching = false;
                         break;
                     }


### PR DESCRIPTION
In this pull request I have added support for sending arrays of arguments to OSCMessage.init and OSCWriter.sendOSC

I have also improved handling of boolean values by checking each argument sent to OSCWriter.sendOSC and converting booleans to their integer equivalent. Before only certain values were being converted, the catch all ensures that all new parameters will be converted correctly.